### PR TITLE
Data 128 xcoms support gad utils

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,7 @@ repos:
     hooks:
     - id: black
       language_version: python
+      args: ["--skip-string-normalization"]
 - repo: https://github.com/pycqa/isort
   rev: 5.11.5
   hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,6 @@ repos:
     hooks:
     - id: black
       language_version: python
-      args: ["--skip-string-normalization"]
 - repo: https://github.com/pycqa/isort
   rev: 5.11.5
   hooks:

--- a/common_utils/gad_utils.py
+++ b/common_utils/gad_utils.py
@@ -214,9 +214,11 @@ def generate_airflow_dag(project: str, dag_id: str, schedule_interval, tasks: li
             dbt_vars = configs.get("dbt_vars")
             if dbt_vars:
                 dbt_vars.update(xcom_val)
-                dbt_all_args = dbt_default_args_and_models + ["--vars", str(dbt_vars)]
+                dbt_all_args = dbt_default_args_and_models + ["--vars", json.dumps(dbt_vars)]
+            elif bool(xcom_val):
+                dbt_all_args = dbt_default_args_and_models + ["--vars", json.dumps(xcom_val)]
             else:
-                dbt_all_args = dbt_default_args_and_models + ["--vars", str(xcom_val)]
+                dbt_all_args = dbt_default_args_and_models
 
             return dbt_all_args
 

--- a/common_utils/gad_utils.py
+++ b/common_utils/gad_utils.py
@@ -4,7 +4,6 @@ from datetime import timedelta
 
 from airflow import DAG
 from airflow.contrib.operators.kubernetes_pod_operator import KubernetesPodOperator
-from airflow.decorators import dag, task
 from airflow.operators.python_operator import PythonOperator
 from airflow.utils.dates import days_ago
 from kubernetes.client import models as k8s
@@ -301,7 +300,7 @@ def generate_airflow_dag(project: str, dag_id: str, schedule_interval, tasks: li
 
     # Iterate through the original tasks list and add each task to the new list
     # If a task has an xcom_push attribute set to True, create a new service task and add it to the new list
-    for i, task in enumerate(tasks):
+    for task in tasks:
         new_tasks_list.append(task)
         if "xcom_push" in task.keys():
             if task["xcom_push"]:
@@ -323,7 +322,7 @@ def generate_airflow_dag(project: str, dag_id: str, schedule_interval, tasks: li
     kubernetes_tasks = {}
 
     # Iterate through each task in the new list and create a KubernetesPodOperator or PythonOperator task based on its properties
-    for i, task in enumerate(new_tasks_list):
+    for task in new_tasks_list:
         # If the task is a service task, create a PythonOperator with parse_xcoms function as its callable
         if "service" in task.keys():
             service_task = PythonOperator(

--- a/common_utils/gad_utils.py
+++ b/common_utils/gad_utils.py
@@ -1,28 +1,32 @@
 import json
 import os
 from datetime import timedelta
-import subprocess
 
 from airflow.contrib.operators.kubernetes_pod_operator import KubernetesPodOperator
+from airflow.operators.python_operator import PythonOperator
 from airflow.utils.dates import days_ago
 from kubernetes.client import models as k8s
-
+from airflow.decorators import dag,task
 from airflow import DAG
 
+import ast
 
 def return_dag_ingrediants(project):
     """
-    Args:
-        project (str): The name of the project.
+    This function returns a tuple that contains various objects used in an Airflow DAG
+    for the specified project.
+
+    Parameters:
+        project (str): The name of the project for which to return the DAG ingredients.
 
     Returns:
-        paths (dict): A dictionary containing various file paths.
-        default_args (dict): A dictionary containing default arguments for the DAG.
-        envConfigMap (k8s.V1EnvFromSource): A reference to configmap that maps environment variables.
-        volume (k8s.V1Volume): A Kubernetes volume.
-        volume_mount (k8s.V1VolumeMount): A Kubernetes volume mount.
+        tuple: A tuple containing the following objects:
+            - paths (dict): A dictionary that maps path-related variables to their respective names.
+            - default_args (dict): A dictionary that specifies default arguments for the DAG.
+            - envFromSource (k8s.V1EnvFromSource): An object that specifies the ConfigMap to use as a source of environment variables.
+            - volumes (list): A list of V1Volume objects that specify the volumes to mount in the Kubernetes Pod.
+            - volumes_mounts (list): A list of V1VolumeMount objects that specify the volume mounts to use in the Kubernetes Pod.
     """
-
     WORK_DIR = "/opt/aiola/projects"
     SUB_FOLDER = os.environ.get("DEPLOYMENT_DIR", "gad-deliveries")
     PROJECT_DIR = f"{WORK_DIR}/{SUB_FOLDER}/{project}"
@@ -57,12 +61,6 @@ def return_dag_ingrediants(project):
     envFromSource = k8s.V1EnvFromSource(
         config_map_ref=configMapEnvSource
     )
-    # environment = []
-
-    # environment = [
-    #     k8s.V1EnvVar(name="PROJECTDIR", value="value1"),
-    #     k8s.V1EnvVar(name="key2", value="value2"),
-    # ]
     
     volume_mount = k8s.V1VolumeMount(
         name="project-volume",
@@ -116,30 +114,39 @@ def generate_airflow_dag(project: str, dag_id: str, schedule_interval, tasks: li
             return "gad-papermill:0.1"
     
     def is_xcom_push_task(task_dict: dict):
-            if 'xcom_push' in task_dict.keys():
-                return task_dict['xcom_push']
-            else:
-                return False  
-            
-    def extract_xcom_values(task_dict: dict):
+        """
+        This function checks if a given task dictionary specifies that its output should be pushed to XCom.
+
+        Parameters:
+            task_dict (dict): A dictionary that represents a task in an Airflow DAG.
+
+        Returns:
+            bool: True if the task's output should be pushed to XCom, False otherwise.
+        """
+        if 'xcom_push' in task_dict.keys():
+            return task_dict['xcom_push']
+        else:
+            return False  
     
-            def extract_xcom_data(task_id:str):
-                # return list("{{ ti.xcom_pull(task_ids=['" + task_id + "']) }}")
-                return [{'start_date': '2023-04-19 14:04:26.278129'}, {'engineer': 'Yaniv Vainer'}, {'age': '12'}]    
-            
-            return_dict = {}
-            if 'xcom_pull' in task_dict.keys():
-                task_id = task_dict['xcom_pull']['task']
-                raw_xcom = extract_xcom_data(task_id)
-                xcoms = task_dict['xcom_pull']['xcoms']
+    def extract_xcom_data(task_dict:dict):
+        """
+        This function extracts XCom data from a given task dictionary.
 
-                return_dict = {}
-                for i in raw_xcom:
-                    key,value = list(i.items())[0]
-                    if key in xcoms:
-                        return_dict[key] = value
+        Parameters:
+            task_dict (dict): A dictionary that represents a task in an Airflow DAG.
 
-            return return_dict
+        Returns:
+            dict: A dictionary containing the XCom data for the task.
+        """
+        return_dict = {}
+        if 'xcom_pull' in task_dict.keys():            
+            task_id = task_dict['xcom_pull']['task']
+            xcoms_list = task_dict['xcom_pull']['xcoms']                   
+            for xcom in xcoms_list:
+                value = "{{ ti.xcom_pull(task_ids=['" + task_id + "_service_task'], key='"+ xcom +"') }}"
+                return_dict[xcom] = value
+        return return_dict  
+        
 
     def return_cmds(task_dict: dict) -> list:
         """Returns a list of command-line commands based on task_dict.
@@ -188,12 +195,7 @@ def generate_airflow_dag(project: str, dag_id: str, schedule_interval, tasks: li
         in the 'python_args' key of the configs dictionary.
         """
 
-        xcom_val = extract_xcom_values(task_dict)
-
-        # if task_dict['xcom_pull_task_id']:
-        #     xcom_val = {'xcom_value': "{{ ti.xcom_pull(task_ids=['" + task_dict['xcom_pull'] + "']) }}"}
-        # else: 
-        #     xcom_val = {}
+        xcom_val = extract_xcom_data(task_dict)
             
         if task_dict["task_type"] == "dbt":
             dbt_default_args = [
@@ -248,6 +250,24 @@ def generate_airflow_dag(project: str, dag_id: str, schedule_interval, tasks: li
             j = f.read()
         return json.loads(j)
 
+    def parse_xcoms(task_id,**kwargs):
+        """
+        This function extracts XCom data from a specified task instance and pushes the data to XCom with individual keys.
+
+        Parameters:
+            task_id (str): The ID of the task instance from which to extract XCom data.
+            **kwargs: A dictionary containing additional keyword arguments. This dictionary must contain the 'ti' key, which
+                    provides the task instance.
+
+        Returns:
+            None
+        """
+        task_instance = kwargs['ti']
+        value = task_instance.xcom_pull(task_ids=task_id)
+        for i in value[0][0].keys():
+            print('xcom push','key',i,'val',value[0][0][i])
+            task_instance.xcom_push(key=i,value=value[0][0][i])
+              
     # dag creation
     dag = DAG(
         dag_id=dag_id,
@@ -260,41 +280,80 @@ def generate_airflow_dag(project: str, dag_id: str, schedule_interval, tasks: li
     configs = return_configs()
     env_vars = configs.get("env_vars")
 
-    # This code is a loop that iterates over a list of tasks and creates a KubernetesPodOperator object for each task.
-    # return_command_args() function is used to obtain the command arguments for the task.
-    # return_image_name() function is used to get the image name based on the task type.
-    # return_configs() function is used to get environment variables.
-    # The KubernetesPodOperator object is then created using these variables and appended to a dictionary named kubernetes_tasks with the task ID as the key.
+    """
+    This code is a loop that iterates over a list of tasks and creates a KubernetesPodOperator object for each task.
+    return_command_args() function is used to obtain the command arguments for the task.
+    return_image_name() function is used to get the image name based on the task type.
+    return_configs() function is used to get environment variables.
+    The KubernetesPodOperator object is then created using these variables and appended to a dictionary named kubernetes_tasks with the task ID as the key.
+    """
+
+    # Define an empty list to store new tasks
+    new_tasks_list=[]
+
+    # Iterate through the original tasks list and add each task to the new list
+    # If a task has an xcom_push attribute set to True, create a new service task and add it to the new list
+    for i, task in enumerate(tasks):
+        new_tasks_list.append(task)
+        if 'xcom_push' in task.keys():
+            if task['xcom_push']:
+                previous_task_id = task['task_id']
+                service_task = {'task_id': f'{previous_task_id}_service_task', 'service': True, 'upstream': [previous_task_id]}
+                new_tasks_list.append(service_task)
+
+    # Set upstream dependencies for each task in the new list
+    for i, task in enumerate(new_tasks_list):
+        if i>0:
+            if 'service' in new_tasks_list[i-1].keys():
+                new_tasks_list[i]['upstream'] = [new_tasks_list[i-1]['task_id']]
+
+    # Define a dictionary to store KubernetesPodOperator and PythonOperator tasks
     kubernetes_tasks = {}
-    for task in tasks:
-        cmds = return_cmds(task)
-        arguments = return_command_args(task, configs)
-        image = return_image_name(task["task_type"])
 
-        kubernetes_task = KubernetesPodOperator(
-            volumes=volumes,
-            volume_mounts=volumes_mounts,
-            env_vars=env_vars,
-            env_from=[envConfigMap],
-            namespace="default",
-            labels={"Task": task["task_type"]},
-            image_pull_policy="Never",
-            name=task["task_id"],
-            task_id=task["task_id"],
-            is_delete_operator_pod=True,
-            get_logs=True,
-            image=image,
-            cmds=cmds,
-            arguments=arguments,
-            dag=dag,
-            do_xcom_push=is_xcom_push_task(task)
-        )
-        kubernetes_tasks[task["task_id"]] = kubernetes_task
+    # Iterate through each task in the new list and create a KubernetesPodOperator or PythonOperator task based on its properties
+    for i,task in enumerate(new_tasks_list):
 
-    # using tge tasks list, and the kubernetes_tasks dictionary - this loop creates the dependancies.
+        # If the task is a service task, create a PythonOperator with parse_xcoms function as its callable
+        if 'service' in task.keys():
+            service_task = PythonOperator(
+                task_id=task['task_id'],
+                python_callable=parse_xcoms,
+                op_args=[task['upstream']],
+                dag=dag
+                )
+            kubernetes_tasks[task["task_id"]] = service_task
+            
+        # If the task is not a service task, create a KubernetesPodOperator
+        else:
+            cmds = return_cmds(task)
+            arguments = return_command_args(task, configs)
+            image = return_image_name(task["task_type"])
+
+            kubernetes_task = KubernetesPodOperator(
+                volumes=volumes,
+                volume_mounts=volumes_mounts,
+                env_vars=env_vars,
+                env_from=[envConfigMap],
+                namespace="default",
+                labels={"Task": task["task_type"]},
+                image_pull_policy="Never",
+                name=task["task_id"],
+                task_id=task["task_id"],
+                is_delete_operator_pod=True,
+                get_logs=True,
+                image=image,
+                cmds=cmds,
+                arguments=arguments,
+                dag=dag,
+                do_xcom_push=is_xcom_push_task(task)
+            )
+            kubernetes_tasks[task["task_id"]] = kubernetes_task
+
+    # using the tasks list, and the kubernetes_tasks dictionary - this loop creates the dependancies.
     # each task in tasks contains a value in the 'upstream' key that tells what is the pervious task (or tasks).
     # the kubernates operator created gets the dependancies and is configured to use them with the set_upstream setting.
-    for task in tasks:
+
+    for task in new_tasks_list:
         if task["upstream"] is None or task["upstream"] == "" or task["upstream"] == []:
             pass
         else:

--- a/common_utils/gad_utils_additionals.py
+++ b/common_utils/gad_utils_additionals.py
@@ -1,15 +1,29 @@
 import subprocess
-from datetime import datetime
 
 
 def write_xcom_to_file(xcom_dict):
+    """
+    Recives a dictionary of items needed to be passed as xcoms.
+    Writes a dictionary to a JSON file.
+
+    Args:
+        xcom_dict (dict): A dictionary to be written to the file.
+
+    Returns:
+        None
+    """
+    # Convert the dictionary to a list of key-value pairs formatted as strings
     str_list = []
     for i in xcom_dict.keys():
         str_list.append(f'\"{i}\": \"{xcom_dict[i]}\"')
+
+    # Join the strings together to form a JSON object
     new_dict = "[{" + ", ".join(str_list) + "}]"
 
+    # Construct a shell command to create the directory and write the JSON object to a file
     bash_command = ["sh", "-c"]
     cmd = f"mkdir -p ../airflow/xcom/;echo '{new_dict}' > ../airflow/xcom/return.json"
     bash_command.append(cmd)
 
+    # Execute the shell command using subprocess.run
     subprocess.run(bash_command)

--- a/common_utils/gad_utils_additionals.py
+++ b/common_utils/gad_utils_additionals.py
@@ -7,8 +7,8 @@ def write_xcom_to_file(xcom_names,xcom_values):
     str_list = []
     for i in range(len(xcom_names)):
         str_list.append(f'\"{xcom_names[i]}\": \"{xcom_values[i]}\"')
-    new_dict = "[{"+"}, {".join(str_list)+"}"+"]" 
-
+    new_dict = "[{" + ", ".join(str_list) + "}]"
+ 
     bash_command = ["sh", "-c"]
     cmd = f"mkdir -p ../airflow/xcom/;echo '{new_dict}' > ../airflow/xcom/return.json"
     bash_command.append(cmd)

--- a/common_utils/gad_utils_additionals.py
+++ b/common_utils/gad_utils_additionals.py
@@ -1,0 +1,16 @@
+import subprocess
+
+def write_xcom_to_file(xcom_names,xcom_values):
+    if len(xcom_names) != len(xcom_values):
+        print('error')
+        #todo: raise exception instead
+    str_list = []
+    for i in range(len(xcom_names)):
+        str_list.append(f'\"{xcom_names[i]}\": \"{xcom_values[i]}\"')
+    new_dict = "[{"+"}, {".join(str_list)+"}"+"]" 
+
+    bash_command = ["sh", "-c"]
+    cmd = f"mkdir -p ../airflow/xcom/;echo '{new_dict}' > ../airflow/xcom/return.json"
+    bash_command.append(cmd)
+
+    subprocess.run(bash_command)

--- a/common_utils/gad_utils_additionals.py
+++ b/common_utils/gad_utils_additionals.py
@@ -1,12 +1,9 @@
 import subprocess
 
-def write_xcom_to_file(xcom_names,xcom_values):
-    if len(xcom_names) != len(xcom_values):
-        print('error')
-        #todo: raise exception instead
+def write_xcom_to_file(xcom_dict):
     str_list = []
-    for i in range(len(xcom_names)):
-        str_list.append(f'\"{xcom_names[i]}\": \"{xcom_values[i]}\"')
+    for i in xcom_dict.keys():
+        str_list.append(f'\"{i}\": \"{xcom_dict[i]}\"')
     new_dict = "[{" + ", ".join(str_list) + "}]"
  
     bash_command = ["sh", "-c"]

--- a/common_utils/gad_utils_additionals.py
+++ b/common_utils/gad_utils_additionals.py
@@ -1,11 +1,13 @@
 import subprocess
+from datetime import datetime
+
 
 def write_xcom_to_file(xcom_dict):
     str_list = []
     for i in xcom_dict.keys():
         str_list.append(f'\"{i}\": \"{xcom_dict[i]}\"')
     new_dict = "[{" + ", ".join(str_list) + "}]"
- 
+
     bash_command = ["sh", "-c"]
     cmd = f"mkdir -p ../airflow/xcom/;echo '{new_dict}' > ../airflow/xcom/return.json"
     bash_command.append(cmd)


### PR DESCRIPTION
# GAD xcoms support
## writing xcoms
Using `gad_utils_additionals` a developer now can write he/her code and the required values can be written to xcoms.
The writing will be done by writing the values to a dictionaries and passing it to `gad_utils_additionals.write_xcom_to_file` 
The values will be written to `../airflow/xcom/return_value.json` as an array of 1 item. 
The Item is the dict.

## xcom push
If a task needs to write an xcom - it needs a key for `xcom_push` = True - as part of the task list.
This will use the json written and upload it to airflow as xcom.
A sidecar container in kubernates will be created for this action.
The result will be an xcom called `return_value` and the value will be the array in a string format.

## service task
After each xcom push task - a service task will be created automatically to parse the `return_value` xcom and to write additional xcoms for each key
The service task is using a Python Operator and not Kubernates Pod Operator.

## xcom pull
if a task needs to use xcoms - it will contain in the task list `xcom_pull` as a dictionary with the task id that created the xcoms and the list of xcoms needed.
The xcoms that will actually get pulled are the ones created by the service task.

## task creation and upstream
The DAG generated is done by looping through a task list.
Since the tasks are created using a list - but we also create additional service tasks - we need need to adjust the list before running the loop - for both creating the airflow tasks and also for applying the upstream.