### PR TITLE
Data 174 args to dag 2

### DIFF
--- a/common_utils/data_loading_management.py
+++ b/common_utils/data_loading_management.py
@@ -65,6 +65,7 @@ class dataLoadingManagement:
         self.from_timestamp = None
         self.to_timestamp = None
 
+        # we define the session here so that it can be used by all the functions
         boto3.setup_default_session(region_name=os.environ.get("REGION"))
 
         self.set_from_and_to_timestamps(as_dates=from_and_to_as_dates)

--- a/common_utils/data_loading_management.py
+++ b/common_utils/data_loading_management.py
@@ -31,8 +31,8 @@ class dataLoadingManagement:
 
     def __init__(
         self,
-        from_timestamp: str,
-        to_timestamp: str,
+        from_timestamp: str = None,
+        to_timestamp: str = None,
         full_load: bool = False,
         full_load_from_timestamp: str = None,
         full_load_from_timestamp_months_back: int = 3,

--- a/common_utils/data_loading_management.py
+++ b/common_utils/data_loading_management.py
@@ -1,4 +1,4 @@
-import argparse
+import ast
 import logging
 import os
 from datetime import datetime
@@ -47,7 +47,7 @@ class dataLoadingManagement:
         """
         self.given_from_timestamp = from_timestamp
         self.given_to_timestamp = to_timestamp
-        self.full_load = full_load
+        self.full_load = ast.literal_eval(full_load)
         self.full_load_from_timestamp = full_load_from_timestamp
         self.full_load_from_timestamp_months_back = full_load_from_timestamp_months_back
 

--- a/common_utils/data_loading_management.py
+++ b/common_utils/data_loading_management.py
@@ -1,8 +1,10 @@
 import argparse
 import logging
+import os
 from datetime import datetime
 
 import awswrangler as wr
+import boto3
 from dateutil.relativedelta import relativedelta
 
 from common_utils.date_time_methods import dateTimeMethods
@@ -14,61 +16,60 @@ class dataLoadingManagement:
     validating the start and end timestamps, and creating the schema if the data is being loaded for the first time.
 
     Args:
-        app_args: An instance of argparse.Namespace, containing command line arguments passed to the application.
+        from_timestamp: A string, representing the start timestamp specified by the user.
+        to_timestamp: A string, representing the end timestamp specified by the user.
+        full_load: A string, indicating whether the data is being loaded for the first time.
+        full_load_from_timestamp: A string, representing the start timestamp to use if the data is being loaded for the first time and the start timestamp is specified by the user.
+        full_load_from_timestamp_months_back: An integer, representing the number of months to
+            go back to calculate the default start timestamp if the data is being loaded for the first time and the start timestamp is not specified by the user.
+        athena_workgroup: A string, representing the name of the Athena workgroup to use.
         timestamp_col_name: A string, representing the name of the column in the source data which contains the timestamp.
         tbl_to_check_max_timestamp: A string, representing the name of the table in the destination database to check for the max timestamp.
         from_and_to_as_dates: A boolean, indicating whether the start and end timestamps should be set as dates (midnight of the given date).
-        create_schema_if_initial_load: A boolean, indicating whether the schema should be created if the data is being loaded for the first time.
-
-    Attributes:
-        given_from_timestamp: A string, representing the start timestamp specified by the user.
-        given_to_timestamp: A string, representing the end timestamp specified by the user.
-        initial_load: A string, indicating whether the data is being loaded for the first time.
-        initial_load_from_timestamp: A string, representing the start timestamp to use if the data is being loaded for the first time and the start timestamp is specified by the user.
-        initial_load_from_timestamp_months_back: An integer, representing the number of months to go back to calculate the default start timestamp if the data is being loaded for the first time and the start timestamp is not specified by the user.
-        dest_schema: A string, representing the name of the destination database.
-        timestamp_col_name: A string, representing the name of the column in the source data which contains the timestamp.
-        tbl_to_check_max_timestamp: A string, representing the name of the table in the destination database to check for the max timestamp.
-        default_from_timestamp: A datetime object, representing the default start timestamp to use if the data is being loaded for the first time and the start timestamp is not specified by the user.
-        from_timestamp: A datetime object, representing the start timestamp to use for the data loading.
-        to_timestamp: A datetime object, representing the end timestamp to use for the data loading.
+        create_schema_if_full_load: A boolean, indicating whether the schema should be created if the data is being loaded for the first time.
     """
 
     def __init__(
         self,
-        app_args: argparse.Namespace,
-        timestamp_col_name: str,
-        tbl_to_check_max_timestamp: str,
+        from_timestamp: str,
+        to_timestamp: str,
+        full_load: bool = False,
+        full_load_from_timestamp: str = None,
+        full_load_from_timestamp_months_back: int = 3,
+        athena_workgroup: str = "primary",
+        timestamp_col_name: str = None,
+        tbl_to_check_max_timestamp: str = None,
         from_and_to_as_dates: bool = False,
-        create_schema_if_initial_load: bool = True,
+        create_schema_if_full_load: bool = True,
     ):
         """
         Initializes the class and sets the start and end timestamps, and creates the schema if the data is being loaded for the first time.
         """
-        self.given_from_timestamp = app_args.from_timestamp
-        self.given_to_timestamp = app_args.to_timestamp
-        self.initial_load = app_args.initial_load
-        self.initial_load_from_timestamp = app_args.initial_load_from_timestamp
-        self.initial_load_from_timestamp_months_back = (
-            app_args.initial_load_from_timestamp_months_back
-        )
-        self.dest_schema = app_args.destination_database_name
-        self.athena_workgroup = app_args.athena_workgroup
+        self.given_from_timestamp = from_timestamp
+        self.given_to_timestamp = to_timestamp
+        self.full_load = full_load
+        self.full_load_from_timestamp = full_load_from_timestamp
+        self.full_load_from_timestamp_months_back = full_load_from_timestamp_months_back
+
+        self.dest_schema = os.environ.get("ATHENA_DB")
+        self.athena_workgroup = athena_workgroup
         self.timestamp_col_name = timestamp_col_name
         self.tbl_to_check_max_timestamp = tbl_to_check_max_timestamp
 
         # to be used if nothing else is given
         self.default_from_timestamp = (
             datetime.now()
-            - relativedelta(months=self.initial_load_from_timestamp_months_back)
+            - relativedelta(months=self.full_load_from_timestamp_months_back)
         ).replace(microsecond=0)
 
         self.from_timestamp = None
         self.to_timestamp = None
 
+        boto3.setup_default_session(region_name=os.environ.get("REGION"))
+
         self.set_from_and_to_timestamps(as_dates=from_and_to_as_dates)
 
-        if create_schema_if_initial_load:
+        if create_schema_if_full_load:
             self.create_schema_if_not_exists()
 
     def set_from_and_to_timestamps(self, as_dates: bool = False):
@@ -82,8 +83,8 @@ class dataLoadingManagement:
             None
         """
         # set from/to_timestamp to fetch all data when the table is recrated
-        if self.initial_load:
-            self.set_from_timestamp_initial_load()
+        if self.full_load:
+            self.set_from_timestamp_full_load()
 
             self.to_timestamp = datetime.now()
         else:
@@ -107,30 +108,30 @@ class dataLoadingManagement:
 
         self.validate_from_and_to_timestamp()
 
-    def set_from_timestamp_initial_load(self):
-        """Sets the from_timestamp for initial load.
+    def set_from_timestamp_full_load(self):
+        """Sets the from_timestamp for full load.
 
-        If `initial_load_from_timestamp` is given, it is used as the `from_timestamp`.
-        If not, the `from_timestamp` is calculated as `initial_load_from_timestamp_months_back` months back from today.
+        If `full_load_from_timestamp` is given, it is used as the `from_timestamp`.
+        If not, the `from_timestamp` is calculated as `full_load_from_timestamp_months_back` months back from today.
         The information about the process is logged.
 
         Returns:
             None
         """
         logging.info(
-            "initial_load is True, so from_timestamp and to_timestamp will be assigned with default values to fetch all data"
+            "full_load is True, so from_timestamp and to_timestamp will be assigned with default values to fetch all data"
         )
-        if self.initial_load_from_timestamp:
+        if self.full_load_from_timestamp:
             logging.info(
-                f"initial_load_from_timestamp is given and will be used as the from_timestamp: {self.initial_load_from_timestamp}"
+                f"full_load_from_timestamp is given and will be used as the from_timestamp: {self.full_load_from_timestamp}"
             )
             self.from_timestamp = dateTimeMethods.get_timestamp(
-                self.initial_load_from_timestamp
+                self.full_load_from_timestamp
             )
         else:
             self.from_timestamp = self.default_from_timestamp
             logging.info(
-                f"initial_load_from_timestamp was NOT given, from_timestamp will be {self.initial_load_from_timestamp_months_back} month back from today: {self.from_timestamp}"
+                f"full_load_from_timestamp was NOT given, from_timestamp will be {self.full_load_from_timestamp_months_back} month back from today: {self.from_timestamp}"
             )
 
     def set_from_timestamp_partial_load(self):
@@ -176,14 +177,14 @@ class dataLoadingManagement:
 
     def create_schema_if_not_exists(self):
         """
-        Check if the "initial_load" attribute is set to True and create the destination schema if it doesn't exist yet.
+        Check if the "full_load" attribute is set to True and create the destination schema if it doesn't exist yet.
 
         Returns:
             None
         """
-        if self.initial_load:
+        if self.full_load:
             logging.info(
-                f"initial load is True. the schema {self.dest_schema} will be created if not exist yet"
+                f"full load is True. the schema {self.dest_schema} will be created if not exist yet"
             )
             wr.athena.start_query_execution(
                 f"create database if not exists {self.dest_schema}"

--- a/common_utils/gad_utils.py
+++ b/common_utils/gad_utils.py
@@ -153,7 +153,9 @@ def generate_airflow_dag(
                     + xcom
                     + "') }}"
                 )
-                return_dict[xcom] = value.replace("[", "").replace("]", "")
+                return_dict[xcom] = value.replace("[", "").replace(
+                    "]", ""
+                )  # this is MANDATORY to make sure we get the right value from XCOM (using [1:-1] doesn't work)
         return return_dict
 
     def return_cmds(task_dict: dict) -> list:

--- a/common_utils/gad_utils.py
+++ b/common_utils/gad_utils.py
@@ -154,7 +154,7 @@ def generate_airflow_dag(
                     + xcom
                     + "') }}"
                 )
-                return_dict[xcom] = value
+                return_dict[xcom] = value.replace("[", "").replace("]", "")
         return return_dict
 
     def return_cmds(task_dict: dict) -> list:
@@ -233,10 +233,6 @@ def generate_airflow_dag(
             return dbt_all_args
 
         elif task_dict["task_type"] == "python":
-            # TODO: add support for xcom_val
-            xcom_val = extract_xcom_data(task_dict)
-            dag_params.update(xcom_val)
-
             list_args = []
             for key in dag_params:
                 list_args.append(f"--{key}")
@@ -249,6 +245,11 @@ def generate_airflow_dag(
                     .replace("[", "")
                     .replace("]", "")
                 )
+
+            xcom_val = extract_xcom_data(task_dict)
+            for key, val in xcom_val.items():
+                list_args.append(f"--{key}")
+                list_args.append(val)
 
             return list_args
 

--- a/common_utils/gad_utils.py
+++ b/common_utils/gad_utils.py
@@ -311,8 +311,11 @@ def generate_airflow_dag(
 
         # push each python arg to xcom
         for arg in args_to_use:
-            if args_to_use[arg]:
+            if args_to_use[arg] != "":
                 kwargs["ti"].xcom_push(key=arg, value=args_to_use[arg])
+
+    # use only the params that are not empty
+    dag_params = {k: v for k, v in dag_params.items() if v != ""}
 
     # dag creation
     dag = DAG(

--- a/common_utils/gad_utils.py
+++ b/common_utils/gad_utils.py
@@ -275,7 +275,7 @@ def generate_airflow_dag(
             # pull initial dbt_vars from xcom
             dbt_vars_dict = task_instance.xcom_pull(
                 task_ids=["digest_args_task"], key="dbt_vars"
-            )
+            )[0]
             # add new dbt vars from XCOM of another task to dbt_vars_dict
             dbt_vars_dict[key] = value[0][0][key]
 

--- a/common_utils/gad_utils.py
+++ b/common_utils/gad_utils.py
@@ -269,7 +269,6 @@ def generate_airflow_dag(
 
         Parameters:
             task_id (str): The ID of the task instance from which to extract XCom data.
-            task_type (str): The type of task that will pull the XCOM. This must be either 'dbt' or 'python'.
             **kwargs: A dictionary containing additional keyword arguments. This dictionary must contain the 'ti' key, which
                     provides the task instance.
 

--- a/common_utils/gad_utils.py
+++ b/common_utils/gad_utils.py
@@ -273,10 +273,9 @@ def generate_airflow_dag(
             print("xcom push", "key", key, "val", value[0][0][key])
 
             # pull initial dbt_vars from xcom
-            dbt_vars = task_instance.xcom_pull(
+            dbt_vars_dict = task_instance.xcom_pull(
                 task_ids=["digest_args_task"], key="dbt_vars"
             )
-            dbt_vars_dict = ast.literal_eval(dbt_vars[0])
             # add new dbt vars from XCOM of another task to dbt_vars_dict
             dbt_vars_dict[key] = value[0][0][key]
 
@@ -303,12 +302,8 @@ def generate_airflow_dag(
 
         print(f"args_to_use: {args_to_use}")
 
-        # create a string of the dbt vars to be used and push to xcom as one string
-        dbt_vars = (
-            "{"
-            + ", ".join([f'"{k}": "{v}"' for k, v in args_to_use.items() if v != ""])
-            + "}"
-        )
+        # create a dict of non-empty dbt vars and push to xcom
+        dbt_vars = {k: str(v) for k, v in args_to_use.items() if v != ""}
         kwargs["ti"].xcom_push(key="dbt_vars", value=dbt_vars)
 
         # push each python arg to xcom

--- a/common_utils/gad_utils.py
+++ b/common_utils/gad_utils.py
@@ -234,7 +234,7 @@ def generate_airflow_dag(
 
         elif task_dict["task_type"] == "python":
             list_args = []
-            for key in dag_params:
+            for key in dag_params_not_empty:
                 list_args.append(f"--{key}")
                 list_args.append(
                     (
@@ -316,7 +316,7 @@ def generate_airflow_dag(
                 kwargs["ti"].xcom_push(key=arg, value=args_to_use[arg])
 
     # use only the params that are not empty
-    dag_params = {k: v for k, v in dag_params.items() if v != ""}
+    dag_params_not_empty = {k: v for k, v in dag_params.items() if v != ""}
 
     # dag creation
     dag = DAG(

--- a/common_utils/gad_utils.py
+++ b/common_utils/gad_utils.py
@@ -418,13 +418,13 @@ def generate_airflow_dag(
             )
             kubernetes_tasks[task["task_id"]] = kubernetes_task
 
+    # Define an empty list to store tasks without upstream dependencies, so we will set
+    # the digest_args_task as their upstream
+    tasks_without_upstream = []
+
     # using the tasks list, and the kubernetes_tasks dictionary - this loop creates the dependancies.
     # each task in tasks contains a value in the 'upstream' key that tells what is the pervious task (or tasks).
     # the kubernates operator created gets the dependancies and is configured to use them with the set_upstream setting.
-
-    # Define an empty list to store tasks without upstream dependencies, so we will set the digest_args_task as their upstream
-    tasks_without_upstream = []
-
     for task in new_tasks_list:
         if task["upstream"] is None or task["upstream"] == "" or task["upstream"] == []:
             tasks_without_upstream.append(kubernetes_tasks[task["task_id"]])

--- a/common_utils/gad_utils.py
+++ b/common_utils/gad_utils.py
@@ -224,7 +224,10 @@ def generate_airflow_dag(
             )
 
             dbt_all_args = (
-                task_dict["dbt_models"] + dbt_default_args + ["--vars", dbt_vars]
+                task_dict["dbt_models"]
+                + dbt_default_args
+                + ["--vars", dbt_vars]
+                + ["--vars", json.dumps(xcom_val)]
             )
 
             return dbt_all_args

--- a/common_utils/gad_utils.py
+++ b/common_utils/gad_utils.py
@@ -277,6 +277,7 @@ def generate_airflow_dag(
                 task_ids=["digest_args_task"], key="dbt_vars"
             )
             dbt_vars_dict = ast.literal_eval(dbt_vars[0])
+            # add new dbt vars from XCOM of another task to dbt_vars_dict
             dbt_vars_dict[key] = value[0][0][key]
 
             # push individual xcoms for python use
@@ -362,7 +363,8 @@ def generate_airflow_dag(
     # Define a dictionary to store KubernetesPodOperator and PythonOperator tasks
     kubernetes_tasks = {}
 
-    last_service_task_id = ""
+    # this variable is used to store the task id of the last task that updated the dbt_vars key in xcom. It can be either "digest_args_task" or a service task. If there are no service tasks - it will be "digest_args_task"
+    last_service_task_id = "digest_args_task"
 
     # Iterate through each task in the new list and create a KubernetesPodOperator or PythonOperator task based on its properties
     for task in new_tasks_list:


### PR DESCRIPTION
The main change in this PR is in the gad-utils.py file and is meant to support passing args to dags. It includes:
- Create the digest_args_task which is a Python operator that loads the dbt and python args to XCOM. It'll be the first task in every dag
- Remove anything that was related to the json config files (as we don't use them anymore)
- For dbt, adding any given XCOM value to the existing dbt_vars XCOM (so there is no need to mention from which task the XCOM value is created)
- For Python, add each XCOM value from digest_args_task to the list of args for the pod
- Get dag params from each dag. The values listed in the dag code will be the default values and can be overridden in the UI (or using the Airflow API)

A secondary change is in the data_loading_management.py file:
- initial_load was changed to full_load in all places
- We now pass explicitly all the params we need in the dlm (instead of passing the Args dict)

This PR goes hand in hand with [this PR](https://github.com/aiola-lab/gad-deliveries/pull/69) in gad-deliveries repo and they must be merged together